### PR TITLE
Conversions for various frictionless datapackage properties

### DIFF
--- a/ckan_datapackage_tools/converter.py
+++ b/ckan_datapackage_tools/converter.py
@@ -128,7 +128,7 @@ def _datapackage_resource_to_ckan_resource(resource):
     elif resource.inline:
         resource_dict['data'] = resource.source
     else:
-        raise NotImplemented('Multipart resources not yet supported')
+        raise NotImplementedError('Multipart resources not yet supported')
 
     if resource.descriptor.get('description'):
         resource_dict['description'] = resource.descriptor['description']

--- a/ckan_datapackage_tools/converter.py
+++ b/ckan_datapackage_tools/converter.py
@@ -241,15 +241,16 @@ def _parse_extra_sources(extras_dict, sources):
         if parsed and parsed.get('title'):
             sources.append(parsed)
 
+
 def _parse_extra_source(extra_source):
     source = {}
     if extra_source.get('name'):
         extra_source['title'] = extra_source.pop('name')
     if extra_source.get('url'):
         extra_source['path'] = extra_source.pop('url')
-    for property in ['title','path','email']:
-        if extra_source.get(property):
-            source[property] = extra_source[property]
+    for prop in ['title', 'path', 'email']:
+        if extra_source.get(prop):
+            source[prop] = extra_source[prop]
     return source
 
 
@@ -287,15 +288,16 @@ def _parse_extra_license(extra_license):
         extra_license['name'] = extra_license.pop('type')
     if extra_license.get('url'):
         extra_license['path'] = extra_license.pop('url')
-    for property in ['name', 'path', 'title']:
-        if extra_license.get(property):
-            license[property] = extra_license[property]
+    for prop in ['name', 'path', 'title']:
+        if extra_license.get(prop):
+            license[prop] = extra_license[prop]
     return license
 
 
 def _parse_primary_contributors(dataset_dict):
     contributors = []
-    for parser in [_parse_author_as_contributor, _parse_maintainer_as_contributor]:
+    for parser in [_parse_author_as_contributor,
+                   _parse_maintainer_as_contributor]:
         parsed = parser(dataset_dict)
         if parsed and parsed.get('title'):
             contributors.append(parsed)
@@ -331,9 +333,9 @@ def _parse_extra_contributors(extras, contributors):
 
 def _parse_extra_contributor(extra_contributor):
     contributor = {}
-    for property in ['title','path','email','role','organization']:
-        if extra_contributor.get(property):
-            contributor[property] = extra_contributor[property]
+    for prop in ['title', 'path', 'email', 'role', 'organization']:
+        if extra_contributor.get(prop):
+            contributor[prop] = extra_contributor[prop]
     return contributor
 
 

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -310,7 +310,6 @@ class TestConvertToDict(unittest.TestCase):
             }]
         })
         result = converter.dataset_to_datapackage(self.dataset_dict)
-        log.info('contributors result %r', result.get('contributors'))
         self.assertEquals(result.get('contributors'), [
             {
                 'title': 'John Smith',

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -92,6 +92,38 @@ class TestConvertToDict(unittest.TestCase):
         }])
         self.assertEquals(result.get('license'), None)
 
+    def test_dataset_license_and_licenses_as_extras(self):
+        primary_license = {
+            'license_id': 'cc-zero',
+            'license_title': 'Creative Commons CC Zero License (cc-zero)',
+            'license_url': 'http://opendefinition.org/licenses/cc-zero/'
+        }
+        extra_licenses = [{
+            'type': 'cc-by-sa',
+            'title': 'Creative Commons Attribution Share-Alike (cc-by-sa)',
+            'url': 'http://www.opendefinition.org/licenses/cc-by-sa/'
+        }]
+        self.dataset_dict.update(primary_license)
+        self.dataset_dict.update({
+            'extras': [{
+                'key':'licenses',
+                'value': extra_licenses
+             }]
+        })
+        result = converter.dataset_to_datapackage(self.dataset_dict)
+        self.assertEquals(result.get('licenses'), [{
+            'name': 'cc-zero',
+            'title': 'Creative Commons CC Zero License (cc-zero)',
+            'path': 'http://opendefinition.org/licenses/cc-zero/'
+        },
+        {
+            'name': 'cc-by-sa',
+            'title': 'Creative Commons Attribution Share-Alike (cc-by-sa)',
+            'path': 'http://www.opendefinition.org/licenses/cc-by-sa/'
+         }
+        ])
+        self.assertEquals(result.get('license'), None)
+
     def test_dataset_author_and_source(self):
         sources = [{
                 "author": "someone",
@@ -162,6 +194,45 @@ class TestConvertToDict(unittest.TestCase):
             self.assertEquals(result['sources'], expected_result)
             self.assertEquals(result.get('source'), None)
 
+    def test_organisation_as_source_and_extra_sources(self):
+        extra_sources = [{
+            'name': 'source1',
+            'email': 'source1@test.com',
+            'url': 'http://source1.com'
+        },
+        {
+            'title': 'source2',
+            'email': 'source2@test.com',
+            'path': 'http://source2.com'
+        }]
+        self.dataset_dict.update({
+            'url' : 'http://worldbankandoecd.com'
+        })
+        self.dataset_dict.update({
+            'extras': [{
+                'key': 'sources',
+                'value': extra_sources
+            }]
+        })
+        result = converter.dataset_to_datapackage(self.dataset_dict)
+        self.assertEquals(result.get('sources'), [
+            {
+                'title': 'World Bank and OECD',
+                'path': 'http://worldbankandoecd.com'
+            },
+            {
+                'title': 'source1',
+                'email': 'source1@test.com',
+                'path': 'http://source1.com'
+            },
+            {
+                'title': 'source2',
+                'email': 'source2@test.com',
+                'path': 'http://source2.com'
+            }
+        ])
+        self.assertEquals(result.get('source'), None)
+
     def test_dataset_author_as_contributor(self):
         self.dataset_dict.update({
             'author': 'John Smith',
@@ -199,6 +270,73 @@ class TestConvertToDict(unittest.TestCase):
         self.assertEquals(result.get('contributors'), expected_result)
         self.assertEquals(result.get('author'), None)
         self.assertEquals(result.get('maintainer'), None)
+
+    def test_dataset_maintainer_and_author_and_extras_as_contributors(self):
+        author = {
+            'author': 'John Smith',
+            'author_email': 'jsmith@email.com',
+        }
+        maintainer = {
+            'maintainer': 'Jane Smith',
+            'maintainer_email': 'janesmith@email.com',
+        }
+        extras = [{
+            'title': 'Bob Smith',
+            'role': 'publisher',
+            'path': 'http://bobsmith.com'
+        },
+        {
+            'name': 'Peter Invalid Smith',
+            'email': 'petersmith@email.com',
+            'role': 'maintainer'
+        },
+        {
+            'email': 'noTitle@email.com',
+            'role': 'contributor'
+        },
+        {
+            'title': 'Jo Smith',
+            'organization': 'org1'
+        },
+        {
+            'title': 'Sam Smith',
+        }]
+        self.dataset_dict.update(author)
+        self.dataset_dict.update(maintainer)
+        self.dataset_dict.update({
+            'extras': [{
+                'key': 'contributors',
+                'value': extras
+            }]
+        })
+        result = converter.dataset_to_datapackage(self.dataset_dict)
+        log.info('contributors result %r', result.get('contributors'))
+        self.assertEquals(result.get('contributors'), [
+            {
+                'title': 'John Smith',
+                'email': 'jsmith@email.com',
+                'role': 'author'
+            },
+            {
+                'title': 'Jane Smith',
+                'email': 'janesmith@email.com',
+                'role': 'maintainer'
+            },
+            {
+                'title': 'Bob Smith',
+                'role': 'publisher',
+                'path': 'http://bobsmith.com'
+            },
+            {
+                'title': 'Jo Smith',
+                'organization': 'org1'
+            },
+            {
+                'title': 'Sam Smith'
+            }
+        ])
+        self.assertEquals(result.get('maintainer'), None)
+        self.assertEquals(result.get('author'), None)
 
     def test_dataset_author_as_contributor_and_source(self):
         self.dataset_dict.update({

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -106,50 +106,42 @@ class TestConvertToDict(unittest.TestCase):
         self.dataset_dict.update(primary_license)
         self.dataset_dict.update({
             'extras': [{
-                'key':'licenses',
+                'key': 'licenses',
                 'value': extra_licenses
-             }]
+            }]
         })
         result = converter.dataset_to_datapackage(self.dataset_dict)
         self.assertEquals(result.get('licenses'), [{
             'name': 'cc-zero',
             'title': 'Creative Commons CC Zero License (cc-zero)',
             'path': 'http://opendefinition.org/licenses/cc-zero/'
-        },
-        {
+        }, {
             'name': 'cc-by-sa',
             'title': 'Creative Commons Attribution Share-Alike (cc-by-sa)',
             'path': 'http://www.opendefinition.org/licenses/cc-by-sa/'
-         }
-        ])
+        }])
         self.assertEquals(result.get('license'), None)
 
     def test_dataset_author_and_source(self):
         sources = [{
-                "author": "someone",
-                "title": "World Bank and OECD Data",
-                "author_email": "someone@worldbank.org",
-                "url": "http://data.worldbank.org/indicator/NY.GDP.MKTP.CD"
-            },
-            {
-                "url": "http://data.worldbank.org/indicator/NY.GDP.MKTP.CD2"
-            },
-            {
-                "title": "World Bank and OECD Data",
-                "url": "http://data.worldbank.org/indicator/NY.GDP.MKTP.CD3"
-            },
-            {
-                "title": "World Bank and OECD",
-                "path": "http://data.worldbank.org/indicator/NY.GDP.MKTP.CD4"
-            },
-            {},
-            {
-                "author_email": "someone6@worldbank.org",
-            },
-            {
-                "url": "http://data.worldbank.org/indicator/NY.GDP.MKTP.CD7"
-            },
-            ]
+            "author": "someone",
+            "title": "World Bank and OECD Data",
+            "author_email": "someone@worldbank.org",
+            "url": "http://data.worldbank.org/indicator/NY.GDP.MKTP.CD"
+        }, {
+            "url": "http://data.worldbank.org/indicator/NY.GDP.MKTP.CD2"
+        }, {
+            "title": "World Bank and OECD Data",
+            "url": "http://data.worldbank.org/indicator/NY.GDP.MKTP.CD3"
+        }, {
+            "title": "World Bank and OECD",
+            "path": "http://data.worldbank.org/indicator/NY.GDP.MKTP.CD4"
+        }, {
+        }, {
+            "author_email": "someone6@worldbank.org",
+        }, {
+            "url": "http://data.worldbank.org/indicator/NY.GDP.MKTP.CD7"
+        }]
         expected_results = [
             [{
                 "title": "World Bank and OECD",
@@ -200,13 +192,13 @@ class TestConvertToDict(unittest.TestCase):
             'email': 'source1@test.com',
             'url': 'http://source1.com'
         },
-        {
-            'title': 'source2',
-            'email': 'source2@test.com',
-            'path': 'http://source2.com'
-        }]
+            {
+                'title': 'source2',
+                'email': 'source2@test.com',
+                'path': 'http://source2.com'
+            }]
         self.dataset_dict.update({
-            'url' : 'http://worldbankandoecd.com'
+            'url': 'http://worldbankandoecd.com'
         })
         self.dataset_dict.update({
             'extras': [{
@@ -285,22 +277,22 @@ class TestConvertToDict(unittest.TestCase):
             'role': 'publisher',
             'path': 'http://bobsmith.com'
         },
-        {
-            'name': 'Peter Invalid Smith',
-            'email': 'petersmith@email.com',
-            'role': 'maintainer'
-        },
-        {
-            'email': 'noTitle@email.com',
-            'role': 'contributor'
-        },
-        {
-            'title': 'Jo Smith',
-            'organization': 'org1'
-        },
-        {
-            'title': 'Sam Smith',
-        }]
+            {
+                'name': 'Peter Invalid Smith',
+                'email': 'petersmith@email.com',
+                'role': 'maintainer'
+            },
+            {
+                'email': 'noTitle@email.com',
+                'role': 'contributor'
+            },
+            {
+                'title': 'Jo Smith',
+                'organization': 'org1'
+            },
+            {
+                'title': 'Sam Smith',
+            }]
         self.dataset_dict.update(author)
         self.dataset_dict.update(maintainer)
         self.dataset_dict.update({

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -23,6 +23,11 @@ class TestConvertToDict(unittest.TestCase):
             'title': 'Countries GDP',
             'version': '1.0',
             'resources': [self.resource_dict],
+            'organization': {
+                'title': 'World Bank',
+                'name': 'World Bank and OECD',
+                'is_organization': True
+            }
         }
 
     def test_basic_dataset_in_setup_is_valid(self):
@@ -36,7 +41,11 @@ class TestConvertToDict(unittest.TestCase):
                 {
                     'name': 'the-resource',
                 }
-            ]
+            ],
+            'organization': {
+                'title': 'World Bank',
+                'name': 'World Bank and OECD'
+            }
 
         }
 
@@ -75,23 +84,100 @@ class TestConvertToDict(unittest.TestCase):
             'license_url': license['url'],
         })
         result = converter.dataset_to_datapackage(self.dataset_dict)
-        self.assertEquals(result.get('license'), license)
+
+        self.assertEquals(result.get('licenses'), [{
+            'name': 'cc-zero',
+            'title': 'Creative Commons CC Zero License (cc-zero)',
+            'path': 'http://opendefinition.org/licenses/cc-zero/'
+        }])
+        self.assertEquals(result.get('license'), None)
 
     def test_dataset_author_and_source(self):
-        sources = [
+        sources = [{
+                "author": "someone",
+                "title": "World Bank and OECD Data",
+                "author_email": "someone@worldbank.org",
+                "url": "http://data.worldbank.org/indicator/NY.GDP.MKTP.CD"
+            },
             {
-                'name': 'World Bank and OECD',
-                'email': 'someone@worldbank.org',
-                'web': 'http://data.worldbank.org/indicator/NY.GDP.MKTP.CD',
+                "url": "http://data.worldbank.org/indicator/NY.GDP.MKTP.CD2"
+            },
+            {
+                "title": "World Bank and OECD Data",
+                "url": "http://data.worldbank.org/indicator/NY.GDP.MKTP.CD3"
+            },
+            {
+                "title": "World Bank and OECD",
+                "path": "http://data.worldbank.org/indicator/NY.GDP.MKTP.CD4"
+            },
+            {},
+            {
+                "author_email": "someone6@worldbank.org",
+            },
+            {
+                "url": "http://data.worldbank.org/indicator/NY.GDP.MKTP.CD7"
+            },
+            ]
+        expected_results = [
+            [{
+                "title": "World Bank and OECD",
+                "path": "http://data.worldbank.org/indicator/NY.GDP.MKTP.CD"
+            }],
+            [{
+                "title": "World Bank and OECD",
+                "path": "http://data.worldbank.org/indicator/NY.GDP.MKTP.CD2"
+            }],
+            [{
+                "title": "World Bank and OECD",
+                "path": "http://data.worldbank.org/indicator/NY.GDP.MKTP.CD3"
+            }],
+            [{
+                "title": "World Bank and OECD"
+            }],
+            [{
+                "title": "World Bank and OECD",
+            }],
+            [{
+                "title": "World Bank and OECD",
+            }],
+            [{
+                "title": "World Bank and OECD",
+                "path": "http://data.worldbank.org/indicator/NY.GDP.MKTP.CD7"
+            }],
+        ]
+        for source, expected_result in zip(sources, expected_results):
+            self.dataset_dict = {
+                'name': 'gdp',
+                'title': 'Countries GDP',
+                'version': '1.0',
+                'resources': [self.resource_dict],
+                'organization': {
+                    'title': 'World Bank',
+                    'name': 'World Bank and OECD',
+                    'is_organization': True
+                }
+            }
+            self.dataset_dict.update(source)
+            result = converter.dataset_to_datapackage(self.dataset_dict)
+            self.assertEquals(result['sources'], expected_result)
+            self.assertEquals(result.get('source'), None)
+
+    def test_dataset_author_as_contributor(self):
+        self.dataset_dict.update({
+            'author': 'John Smith',
+            'author_email': 'jsmith@email.com'
+        })
+        expected_result = [
+            {
+                'title': 'John Smith',
+                'email': 'jsmith@email.com',
+                'role': 'author'
             }
         ]
-        self.dataset_dict.update({
-            'author': sources[0]['name'],
-            'author_email': sources[0]['email'],
-            'url': sources[0]['web']
-        })
         result = converter.dataset_to_datapackage(self.dataset_dict)
-        self.assertEquals(result.get('sources'), sources)
+        self.assertEquals(result.get('contributors'), expected_result)
+        self.assertEquals(result.get('author'), None)
+        self.assertEquals(result.get('maintainer'), None)
 
     def test_dataset_maintainer(self):
         author = {
@@ -102,8 +188,36 @@ class TestConvertToDict(unittest.TestCase):
             'maintainer': author['name'],
             'maintainer_email': author['email'],
         })
+        expected_result = [
+            {
+                'title': 'John Smith',
+                'email': 'jsmith@email.com',
+                'role': 'maintainer'
+            }
+        ]
         result = converter.dataset_to_datapackage(self.dataset_dict)
-        self.assertEquals(result.get('author'), author)
+        self.assertEquals(result.get('contributors'), expected_result)
+        self.assertEquals(result.get('author'), None)
+        self.assertEquals(result.get('maintainer'), None)
+
+    def test_dataset_author_as_contributor_and_source(self):
+        self.dataset_dict.update({
+            'author': 'John Smith',
+            'author_email': 'jsmith@email.com',
+            'url': 'http://data.worldbank.org/indicator/NY.GDP.MKTP.CD'
+        })
+        expected_sources = [{
+            "title": "World Bank and OECD",
+            "path": "http://data.worldbank.org/indicator/NY.GDP.MKTP.CD"
+        }]
+        expected_contributors = [{
+            'title': 'John Smith',
+            'email': 'jsmith@email.com',
+            'role': 'author'
+        }]
+        result = converter.dataset_to_datapackage(self.dataset_dict)
+        self.assertEquals(result['sources'], expected_sources)
+        self.assertEquals(result['contributors'], expected_contributors)
 
     def test_dataset_tags(self):
         keywords = [


### PR DESCRIPTION
Hi @amercader, 

First PR, tracked from project put together by @Stephen-Gates and ODIQueensland.

Following [latest frictionless datapackage spec](https://frictionlessdata.io/specs/data-package/):
Fixes for:
- licenses (including extras)
- sources (using url and organization as primary, and extras)
- profile
- contributors (maintainer and author, and extras)

Used references from:
#2
https://github.com/frictionlessdata/ckanext-datapackager/issues/59
https://github.com/frictionlessdata/ckanext-datapackager/issues/62

@amercader
I figured that once I work on datapackage upload, source organization can be checked and if a match will pull in the url.
Otherwise have tried to follow code-style and conversations with @Stephen-Gates 
I've updated tests, but please let me know if more needed.
Other PRs to follow, so feedback welcome.