### PR TITLE
Corrected duplicate resource name count

### DIFF
--- a/ckan_datapackage_tools/converter.py
+++ b/ckan_datapackage_tools/converter.py
@@ -132,7 +132,7 @@ def _datapackage_resource_to_ckan_resource(resource):
     elif resource.inline:
         resource_dict['data'] = resource.source
     else:
-        raise NotImplemented('Multipart resources not yet supported')
+        raise NotImplementedError('Multipart resources not yet supported')
 
     if resource.descriptor.get('description'):
         resource_dict['description'] = resource.descriptor['description']

--- a/ckan_datapackage_tools/converter.py
+++ b/ckan_datapackage_tools/converter.py
@@ -79,8 +79,9 @@ def dataset_to_datapackage(dataset_dict):
     names = {}
     for resource in dp.get('resources', []):
         if resource['name'] in names.keys():
-            resource['name'] = resource['name'] + str(names[resource['name']])
-            names[resource['name']] += 1
+            old_resource_name = resource['name']
+            resource['name'] = resource['name'] + str(names[old_res_name])
+            names[old_res_name] += 1
         else:
             names[resource['name']] = 0
 

--- a/ckan_datapackage_tools/converter.py
+++ b/ckan_datapackage_tools/converter.py
@@ -80,8 +80,8 @@ def dataset_to_datapackage(dataset_dict):
     for resource in dp.get('resources', []):
         if resource['name'] in names.keys():
             old_resource_name = resource['name']
-            resource['name'] = resource['name'] + str(names[old_res_name])
-            names[old_res_name] += 1
+            resource['name'] = resource['name'] + str(names[old_resource_name])
+            names[old_resource_name] += 1
         else:
             names[resource['name']] = 0
 


### PR DESCRIPTION
Previous code was appending a numerical value to the duplicate resource name, then trying to use the new name for dictionary lookup before incrementing it. This was causing a KeyError.



